### PR TITLE
Improve build settings

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+rustflags = ["-C", "target-cpu=native"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,5 +29,14 @@ pacbot-rs = { git = "https://github.com/RIT-MDRC/pacbot-rs.git", rev = "2601948d
 egui-phosphor = "=0.3.1"
 bevy_egui = "0.24.0"
 bevy_ecs = { version = "0.12.1", features = ["multi-threaded"] }
-bevy = { version = "0.12.1" }
+bevy = { version = "0.12.1", features = ["dynamic_linking"] }
 # rerun = "0.12.1"
+
+
+# Enable a small amount of optimization in debug mode
+[profile.dev]
+opt-level = 1
+
+# Enable high optimizations for dependencies (incl. Bevy), but not for our code:
+[profile.dev.package."*"]
+opt-level = 3


### PR DESCRIPTION
 - Pass `-C target-cpu=native` to rustc to generate code that can take advantage of all instructions for the current CPU.
 - In debug builds, set `opt-level` to `1` for our code and `3` for dependencies. This gives a big runtime performance boost for little extra compile time.
 - Enable the `bevy/dynamic_linking` feature to reduce (re)build times.