### PR TITLE
Remove Game Multithreading

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3377,7 +3377,7 @@ dependencies = [
 [[package]]
 name = "pacbot-rs"
 version = "0.1.0"
-source = "git+https://github.com/RIT-MDRC/pacbot-rs.git?rev=2601948dac7b7debabbb61322a453a770ae83240#2601948dac7b7debabbb61322a453a770ae83240"
+source = "git+https://github.com/RIT-MDRC/pacbot-rs.git?rev=f6b10808a6ad820408aa2602e536ba7985c59b1c#f6b10808a6ad820408aa2602e536ba7985c59b1c"
 dependencies = [
  "array-init",
  "byteorder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ tokio = { version = "1.32.0", features = ["macros", "parking_lot", "rt", "time",
 tokio-tungstenite = "0.20.1"
 array-init = "2.1.0"
 ndarray = "0.15.6"
-pacbot-rs = { git = "https://github.com/RIT-MDRC/pacbot-rs.git", rev = "2601948dac7b7debabbb61322a453a770ae83240" }
+pacbot-rs = { git = "https://github.com/RIT-MDRC/pacbot-rs.git", rev = "f6b10808a6ad820408aa2602e536ba7985c59b1c" }
 egui-phosphor = "=0.3.1"
 bevy_egui = "0.24.0"
 bevy_ecs = { version = "0.12.1", features = ["multi-threaded"] }

--- a/src/gui/game.rs
+++ b/src/gui/game.rs
@@ -13,6 +13,7 @@ use eframe::egui::{Painter, Pos2, Rect, RichText, Rounding, Stroke};
 use pacbot_rs::game_engine::GameEngine;
 use serde::{Deserialize, Serialize};
 use std::time::{Duration, Instant};
+use bevy::utils::tracing::info;
 
 /// Stores state needed to render game state information
 #[derive(Clone, Serialize, Deserialize)]
@@ -67,7 +68,7 @@ pub fn update_game(
         if !pacman_state.0.is_paused() && last_update.elapsed() > Duration::from_secs_f32(1.0 / 2.5)
         {
             *last_update = Instant::now();
-            pacman_state.0.force_step()
+            pacman_state.0.force_step();
         }
     }
 }
@@ -101,7 +102,6 @@ impl<'a> TabViewer<'a> {
 
         // ghosts
         for ghost in &pacman_state.get_state().ghosts {
-            let ghost = ghost.read().unwrap();
             painter.circle_filled(
                 world_to_screen.map_point(Pos2::new(ghost.loc.row as f32, ghost.loc.col as f32)),
                 world_to_screen.map_dist(0.45),

--- a/src/high_level.rs
+++ b/src/high_level.rs
@@ -52,12 +52,7 @@ pub fn run_high_level(
         ai_stopwatch.0.start();
 
         let mut path = vec![];
-        let sim_engine =
-            bincode::serde::encode_to_vec(&game_state.0, bincode::config::standard()).unwrap();
-        let mut sim_engine: GameEngine =
-            bincode::serde::decode_from_slice(&sim_engine, bincode::config::standard())
-                .unwrap()
-                .0;
+        let mut sim_engine = game_state.0.clone();
         let mut curr_pos = IntLocation {
             row: sim_engine.get_state().pacman_loc.row,
             col: sim_engine.get_state().pacman_loc.col,
@@ -227,7 +222,6 @@ impl HighLevelContext {
         let new_ghost_pos_cached: Vec<_> = game_state
             .ghosts
             .iter()
-            .map(|g| g.read().unwrap())
             .map(|g| {
                 if g.loc.col != 32 {
                     Some((g.loc.col as usize, ((31 - g.loc.row - 1) as usize)))
@@ -266,7 +260,6 @@ impl HighLevelContext {
         }
 
         for (i, g) in game_state.ghosts.iter().enumerate() {
-            let g = g.read().unwrap();
             if let Some((col, row)) = new_ghost_pos_cached[i] {
                 ghost[(i, col, row)] = 1.0;
                 if g.is_frightened() {

--- a/src/pathing.rs
+++ b/src/pathing.rs
@@ -57,22 +57,25 @@ pub fn target_path_to_target_vel(
         let curr_pos = curr_pos.translation.vector.xy();
         let target_pos = Vector2::new(target_pos.row as f32, target_pos.col as f32);
 
-        let max_speed = 6.;
+        let base_speed = 4.;
+        let speed_mul = 1.5;
         let mut delta_pos = target_pos - curr_pos;
 
-        let mut barrel_through = false;
-        if let Some(target_pos_next) = target_path.0.get(1) {
-            // Barrel through if next position is in the same direction
-            let delta_pos_next =
-                Vector2::new(target_pos_next.row as f32, target_pos_next.col as f32) - curr_pos;
-            if delta_pos_next.normalize().dot(&delta_pos.normalize()) > 0.95 {
-                barrel_through = true;
+        // Check how many of the next moves are in the same direction
+        let mut adj_nodes = 0;
+        let mut prev_pos = curr_pos;
+        for target_pos_next in &target_path.0.as_slice()[1..] {
+            let target_pos_next =
+                Vector2::new(target_pos_next.row as f32, target_pos_next.col as f32);
+            let delta_pos_next = target_pos_next - prev_pos;
+            if delta_pos_next.normalize().dot(&delta_pos.normalize()) <= 0.95 {
+                break;
             }
+            adj_nodes += 1;
+            prev_pos = target_pos_next;
         }
-        if barrel_through || delta_pos.magnitude() > max_speed {
-            delta_pos = delta_pos.normalize() * max_speed;
-        } else {
-            delta_pos *= 4.;
+        if delta_pos.magnitude_squared() > 0.1 {
+            delta_pos = delta_pos.normalize() * (base_speed + speed_mul * adj_nodes as f32);
         }
 
         target_velocity.0 = delta_pos;

--- a/src/pathing.rs
+++ b/src/pathing.rs
@@ -57,11 +57,14 @@ pub fn target_path_to_target_vel(
         let curr_pos = curr_pos.translation.vector.xy();
         let target_pos = Vector2::new(target_pos.row as f32, target_pos.col as f32);
 
+        // The final speed will be min(max_speed, base_speed + speed_mul * num_straight_moves)
         let base_speed = 4.;
         let speed_mul = 1.5;
+        let max_speed = 10.;
         let mut delta_pos = target_pos - curr_pos;
 
-        // Check how many of the next moves are in the same direction
+        // Check how many of the next moves are in the same direction.
+        // For each one, we slightly increase the speed.
         let mut adj_nodes = 0;
         let mut prev_pos = curr_pos;
         for target_pos_next in &target_path.0.as_slice()[1..] {
@@ -75,7 +78,7 @@ pub fn target_path_to_target_vel(
             prev_pos = target_pos_next;
         }
         if delta_pos.magnitude_squared() > 0.1 {
-            delta_pos = delta_pos.normalize() * (base_speed + speed_mul * adj_nodes as f32);
+            delta_pos = delta_pos.normalize() * f32::min(max_speed, base_speed + speed_mul * adj_nodes as f32);
         }
 
         target_velocity.0 = delta_pos;


### PR DESCRIPTION
Removes multithreading from the game (mainly the ghost stuff), allowing the game state to be easily cloned.
Also took the opportunity to make pathing better, doubling back has been removed + our robot increases its speed for each next tile that faces in the same direction. With these improvements, Pacbot is now almost unkillable.