### PR TITLE
Simulated CV Location Uses Simulated Position Instead of Localization

### DIFF
--- a/core_pb/src/messages/settings.rs
+++ b/core_pb/src/messages/settings.rs
@@ -74,6 +74,7 @@ pub enum CvLocationSource {
     GameState,
     Constant(Option<Point2<i8>>),
     Localization,
+    Simulation,
 }
 
 /// Generic network connection settings

--- a/gui_pb/src/drawing/settings.rs
+++ b/gui_pb/src/drawing/settings.rs
@@ -598,7 +598,11 @@ fn draw_settings_inner(app: &mut App, ui: &mut Ui, fields: &mut HashMap<String, 
         "cv_location".to_string(),
         "CV Location",
         &mut app.settings.cv_location_source,
-        &[CvLocationSource::GameState, CvLocationSource::Localization],
+        &[
+            CvLocationSource::GameState,
+            CvLocationSource::Localization,
+            CvLocationSource::Simulation,
+        ],
     );
     ui.end_row();
 }

--- a/gui_pb/src/input.rs
+++ b/gui_pb/src/input.rs
@@ -373,7 +373,7 @@ impl App {
                                 self.settings.cv_location_source = CvLocationSource::GameState
                             }
                             Key::H => {
-                                self.settings.cv_location_source = CvLocationSource::Localization
+                                self.settings.cv_location_source = CvLocationSource::Simulation
                             }
                             Key::T => {
                                 if let Some(pos) = self.pointer_pos {

--- a/server_pb/src/main.rs
+++ b/server_pb/src/main.rs
@@ -447,6 +447,10 @@ impl App {
                 .estimated_location
                 .and_then(|p| self.grid.node_nearest(p.x, p.y))
                 .or(old_loc),
+            CvLocationSource::Simulation => self.status.robots[self.settings.pacman as usize]
+                .sim_position
+                .and_then(|p| self.grid.node_nearest(p.0.x, p.0.y))
+                .or(old_loc),
         };
 
         if old_loc != self.status.cv_location {


### PR DESCRIPTION
Keeps localization option for cv_location, but allows user to use simulated position instead. Prevents cv_location from being too far away from actual simulated location.