### PR TITLE
Add robot wall stick

### DIFF
--- a/server_pb/src/main.rs
+++ b/server_pb/src/main.rs
@@ -350,10 +350,13 @@ impl App {
                         } else {
                             break;
                         }
+
+                        // move pacman and step simulation forward
                         future.set_pacman_location((
                             future.pacman_loc.row + rl_vec.0,
                             future.pacman_loc.col + rl_vec.1,
                         ));
+                        future.step();
                     }
 
                     self.inference_timer.mark_completed("inference").unwrap();

--- a/sim_pb/src/main.rs
+++ b/sim_pb/src/main.rs
@@ -1,3 +1,4 @@
+use bevy::log::tracing_subscriber::fmt::time;
 use bevy::prelude::*;
 use bevy_rapier2d::na::Vector2;
 use bevy_rapier2d::prelude::*;
@@ -9,7 +10,7 @@ use core_pb::names::{RobotName, NUM_ROBOT_NAMES};
 
 use crate::driving::SimRobot;
 use crate::network::{update_network, PacbotNetworkSimulation};
-use crate::physics::spawn_walls;
+use crate::physics::{spawn_walls, apply_robot_wall_stick};
 
 #[allow(dead_code)]
 mod delayed_value;
@@ -51,6 +52,7 @@ fn main() {
         .add_systems(Startup, setup_physics)
         .add_systems(Update, keyboard_input)
         .add_systems(Update, update_network)
+        .add_systems(Update, apply_robot_wall_stick)
         .add_systems(Update, robot_position_to_game_state)
         .run();
 }
@@ -64,6 +66,7 @@ fn setup_graphics(mut commands: Commands) {
 fn setup_physics(app: ResMut<MyApp>, mut commands: Commands) {
     spawn_walls(&mut commands, app.standard_grid);
 }
+
 
 fn robot_position_to_game_state(
     app: ResMut<MyApp>,

--- a/sim_pb/src/main.rs
+++ b/sim_pb/src/main.rs
@@ -1,4 +1,3 @@
-use bevy::log::tracing_subscriber::fmt::time;
 use bevy::prelude::*;
 use bevy_rapier2d::na::Vector2;
 use bevy_rapier2d::prelude::*;

--- a/sim_pb/src/physics.rs
+++ b/sim_pb/src/physics.rs
@@ -52,15 +52,15 @@ pub fn apply_robot_wall_stick(
 
     for contact_force_event in contact_force_events.read() {
         let force_direction = contact_force_event.max_force_direction;
-        let mut robot = if let Ok(robot) = robots.get_mut(contact_force_event.collider1) {
-            robot
+        let (mut robot, multiplier) = if let Ok(robot) = robots.get_mut(contact_force_event.collider1) {
+            (robot, 1.0)
         } else if let Ok(robot) = robots.get_mut(contact_force_event.collider2) {
-            robot
+            (robot, -1.0)
         } else {
             continue;
         };
 
-        robot.force = Vec2::new(force_direction.x, force_direction.y) * STICK_FORCE;
+        robot.force = Vec2::new(force_direction.x, force_direction.y) * multiplier * STICK_FORCE;
     }
 }
 


### PR DESCRIPTION
Adds a subtle effect that causes the robot to stick and rotate more when it touches a wall. Should be useful for testing algorithms that avoid touching walls and can recover gracefully