### PR TITLE
Fix 'Build & Deploy Documentation' workflow

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -2,9 +2,18 @@ name: Build and Deploy Documentation
 
 on:
   push:
-    branches:
-      - main
+    branches: ["main"]
+    paths:
+      - 'book/'
+  pull_request:
+    branches: ["main"]
+    paths:
+      - 'book/'
   workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   build_and_deploy:
@@ -20,6 +29,9 @@ jobs:
         uses: peaceiris/actions-mdbook@v1
         with:
           mdbook-version: 'latest'
+
+      - name: Install Mermaid
+        run: cargo +stable install mdbook-mermaid
 
       - run: mdbook build book
 


### PR DESCRIPTION
Installs Mermaid and makes sure book isn't recompiled unless necessary. Also adds concurrency support to avoid the race condition when there are multiple pushes to `main` in a short period of time.