### PR TITLE
Add Competition Mode Button

### DIFF
--- a/gui_pb/src/drawing/settings.rs
+++ b/gui_pb/src/drawing/settings.rs
@@ -2,11 +2,11 @@ use crate::App;
 use core_pb::constants::GUI_LISTENER_PORT;
 use core_pb::messages::common::LocalizationAlgorithmSource;
 use core_pb::messages::settings::{
-    ConnectionSettings, CvLocationSource, ShouldDoTargetPath,
-    StrategyChoice,
+    ConnectionSettings, CvLocationSource, ShouldDoTargetPath, StrategyChoice,
 };
 use core_pb::messages::{
-    FrequentServerToRobot, GameServerCommand, GuiToServerMessage, NetworkStatus, ServerToRobotMessage, ServerToSimulationMessage
+    FrequentServerToRobot, GameServerCommand, GuiToServerMessage, NetworkStatus,
+    ServerToRobotMessage, ServerToSimulationMessage,
 };
 use core_pb::names::{RobotName, NUM_ROBOT_NAMES};
 use core_pb::threaded_websocket::TextOrT;
@@ -18,6 +18,14 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fmt::Debug;
 use std::str::FromStr;
+
+const COMP_DO_TARGET_PATH: ShouldDoTargetPath = ShouldDoTargetPath::DoWhilePlayed;
+const COMP_TARGET_SPEED: f32 = 4.0;
+const COMP_LOOKAHEAD_DIST: f32 = 2.0;
+const COMP_ROBOT_SPEED: f32 = 4.0;
+const COMP_TURN_SPEED_MULT: f32 = 0.1;
+const COMP_SNAPPING_DIST: f32 = 0.2;
+const COMP_CV_ERROR: f32 = 1.5;
 
 pub struct UiSettings {
     pub selected_robot: RobotName,
@@ -286,23 +294,23 @@ fn draw_settings_inner(app: &mut App, ui: &mut Ui, fields: &mut HashMap<String, 
     ui.checkbox(&mut app.settings.safe_mode, "Safe mode");
     ui.end_row();
     if ui.button("Competition mode").clicked() {
-        app.settings.do_target_path = ShouldDoTargetPath::DoWhilePlayed;
-        app.settings.target_speed = 4.0;
+        app.settings.do_target_path = COMP_DO_TARGET_PATH;
+        app.settings.target_speed = COMP_TARGET_SPEED;
         app.settings.robots[app.ui_settings.selected_robot as usize]
             .config
-            .lookahead_dist = 2.0;
+            .lookahead_dist = COMP_LOOKAHEAD_DIST;
         app.settings.robots[app.ui_settings.selected_robot as usize]
             .config
-            .robot_speed = 4.0;
+            .robot_speed = COMP_ROBOT_SPEED;
         app.settings.robots[app.ui_settings.selected_robot as usize]
             .config
-            .turn_multiplier = 0.1;
+            .turn_multiplier = COMP_TURN_SPEED_MULT;
         app.settings.robots[app.ui_settings.selected_robot as usize]
             .config
-            .snapping_dist = 0.2;
+            .snapping_dist = COMP_SNAPPING_DIST;
         app.settings.robots[app.ui_settings.selected_robot as usize]
             .config
-            .cv_error = 1.5;
+            .cv_error = COMP_CV_ERROR;
     }
     ui.end_row();
     dropdown(
@@ -404,11 +412,11 @@ fn draw_settings_inner(app: &mut App, ui: &mut Ui, fields: &mut HashMap<String, 
         ui,
         fields,
         &mut app.settings.robots[app.ui_settings.selected_robot as usize]
-        .config
-        .turn_multiplier,
+            .config
+            .turn_multiplier,
         "Turn speed multiplier",
-        true
-        );
+        true,
+    );
 
     num(
         "snapping_distance".to_string(),

--- a/gui_pb/src/drawing/settings.rs
+++ b/gui_pb/src/drawing/settings.rs
@@ -6,8 +6,7 @@ use core_pb::messages::settings::{
     StrategyChoice,
 };
 use core_pb::messages::{
-    GameServerCommand, GuiToServerMessage, NetworkStatus, ServerToRobotMessage,
-    ServerToSimulationMessage,
+    FrequentServerToRobot, GameServerCommand, GuiToServerMessage, NetworkStatus, ServerToRobotMessage, ServerToSimulationMessage
 };
 use core_pb::names::{RobotName, NUM_ROBOT_NAMES};
 use core_pb::threaded_websocket::TextOrT;
@@ -285,6 +284,26 @@ fn draw_settings_inner(app: &mut App, ui: &mut Ui, fields: &mut HashMap<String, 
     });
     ui.end_row();
     ui.checkbox(&mut app.settings.safe_mode, "Safe mode");
+    ui.end_row();
+    if ui.button("Competition mode").clicked() {
+        app.settings.do_target_path = ShouldDoTargetPath::DoWhilePlayed;
+        app.settings.target_speed = 4.0;
+        app.settings.robots[app.ui_settings.selected_robot as usize]
+            .config
+            .lookahead_dist = 2.0;
+        app.settings.robots[app.ui_settings.selected_robot as usize]
+            .config
+            .robot_speed = 4.0;
+        app.settings.robots[app.ui_settings.selected_robot as usize]
+            .config
+            .turn_multiplier = 0.1;
+        app.settings.robots[app.ui_settings.selected_robot as usize]
+            .config
+            .snapping_dist = 0.2;
+        app.settings.robots[app.ui_settings.selected_robot as usize]
+            .config
+            .cv_error = 1.5;
+    }
     ui.end_row();
     dropdown(
         ui,


### PR DESCRIPTION
Adds a button to the UI that sets the robots settings to a mode specifically for competitions. Current competition config is a placeholder.