### PR TITLE
Read cargo manifest directory at runtime

### DIFF
--- a/server_pb/src/main.rs
+++ b/server_pb/src/main.rs
@@ -538,7 +538,11 @@ impl App {
                 self.sim_game_engine_process = Some(
                     Command::new("cargo")
                         .args(["run", "--bin", "sim_pb"])
-                        .current_dir(env!("CARGO_MANIFEST_DIR").to_string() + "/../")
+                        .current_dir(
+                            std::env::var("CARGO_MANIFEST_DIR")
+                                .expect("No cargo manifest directory")
+                                + "/../",
+                        )
                         .spawn()
                         .unwrap(),
                 );


### PR DESCRIPTION
Sometimes directory structure changes between compile-time and runtime [e.g. need to move the finished binary around]. Because the `env!` macro reads the value of `CARGO_MANIFEST_DIR` at compile time, if the structure changes at all between compile- and runtime, the code won't be able to find the `sim_pb` causing a panic. Since the `CARGO_MANIFEST_DIR` is also present at runtime, this alleviates the panic; and if the variable isn't present, it provides a descriptive panic message instead of the cascading `unwrap()`s.