### PR TITLE
Update apt before installing packages

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -38,7 +38,7 @@ jobs:
         run: rustup target add thumbv6m-none-eabi
 
       - name: Install packages
-        run: sudo apt-get install g++ pkg-config libx11-dev libasound2-dev libudev-dev libxkbcommon-x11-0
+        run: sudo apt-get update && sudo apt-get install g++ pkg-config libx11-dev libasound2-dev libudev-dev libxkbcommon-x11-0
 
       - name: Build gui_pb
         working-directory: gui_pb


### PR DESCRIPTION
For when apt mirrors go down, it's helpful to update before attempting to install the packages needed for the CI/CD pipeline.