### PR TITLE
better error message when launching simulation with game server

### DIFF
--- a/sim_pb/src/main.rs
+++ b/sim_pb/src/main.rs
@@ -46,7 +46,7 @@ fn main() {
             robots: RobotName::get_all().map(|_| None),
             selected_robot: RobotName::Stella,
         })
-        .insert_resource(PacbotNetworkSimulation::new().unwrap())
+        .insert_resource(PacbotNetworkSimulation::new().expect("Failed to launch simulation. Make sure the game server is not running at the same time on the same machine."))
         .add_systems(Startup, setup_graphics)
         .add_systems(Startup, setup_physics)
         .add_systems(Update, keyboard_input)


### PR DESCRIPTION
The default unwrap panic message displayed when trying to launch the simulation while the game server is running on the same machine is not descriptive enough.